### PR TITLE
BAH-2564 | Remove Host Header Injection Vulnerability

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - bahmni-master
-      - BAH-2564
     tags:
       - "*"
   pull_request:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - bahmni-master
+      - BAH-2564
     tags:
       - "*"
   pull_request:

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -19,5 +19,5 @@ class TrustProxies extends Middleware
      *
      * @var array
      */
-    protected $headers = Request::HEADER_X_FORWARDED_ALL;
+    protected $headers = Request::HEADER_X_FORWARDED_FOR;
 }


### PR DESCRIPTION
- Host Header injection vulnerability fixed through modifying TrustProxies middleware in PHP. 