### PR TITLE
[Rahul] | BAH-3005 | Add. tzdata Installation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,8 @@ RUN apk update && apk add --no-cache --virtual \
     imagemagick \
     imagemagick-dev \
     mariadb-client \
-    gettext
+    gettext \
+    tzdata
 
 # Install PHP extensions
 RUN docker-php-ext-install pdo_mysql mbstring zip exif pcntl bcmath gd


### PR DESCRIPTION
Jira Card -> https://bahmni.atlassian.net/browse/BAH-3005

As part of card BAH-3005, it was noticed that all docker containers use UTC as their default timezone and to fix this we have added a TZ environment variable to https://github.com/Bahmni/bahmni-docker/pull/45. In our PAT call (Wed, 24 May 2023) it was decided that we we will install the tzdata package in crater Dockerfile so as to make use of TZ environment variable to configure the timezone for the bahmni-proxy container.